### PR TITLE
Fix CLI

### DIFF
--- a/cookie_composer/cli.py
+++ b/cookie_composer/cli.py
@@ -159,5 +159,6 @@ def link():
     """Link an existing project to a template or composition."""
     pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     cli()

--- a/cookie_composer/cli.py
+++ b/cookie_composer/cli.py
@@ -123,7 +123,7 @@ def create(
     is_flag=True,
     help="Do not load a config file. Use the defaults instead",
 )
-@click.argument("path_or_url", type=str, required=True, help="The template or composition path or URL")
+@click.argument("path_or_url", type=str, required=True)
 @click.argument(
     "destination", required=False, type=click.Path(exists=True, file_okay=False, writable=True, path_type=Path)
 )

--- a/cookie_composer/cli.py
+++ b/cookie_composer/cli.py
@@ -158,3 +158,6 @@ def update():
 def link():
     """Link an existing project to a template or composition."""
     pass
+
+if __name__ == '__main__':
+    cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+from click.testing import CliRunner
+import pytest
+
+from cookie_composer import cli
+
+
+@pytest.fixture(scope="module")
+def runner():
+    return CliRunner()
+
+
+def test_helps(runner):
+    result = runner.invoke(cli.create, "--help")
+    assert result.exit_code == 0
+    result = runner.invoke(cli.add, "--help")
+    assert result.exit_code == 0
+    result = runner.invoke(cli.update, "--help")
+    assert result.exit_code == 0
+    result = runner.invoke(cli.link, "--help")
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 from cookie_composer import cli
 


### PR DESCRIPTION
click.argument decorator does not accept `help` kwarg

```
❯ cookie-composer [any command]
Traceback (most recent call last):
  File "/Users/*******/.local/bin/cookie-composer", line 5, in <module>
    from cookie_composer.cli import cli
  File "/Users/*******/.local/pipx/venvs/cookie-composer/lib/python3.10/site-packages/cookie_composer/cli.py", line 130, in <module>
    def add(
  File "/Users/*******/.local/pipx/venvs/cookie-composer/lib/python3.10/site-packages/click/decorators.py", line 287, in decorator
    _param_memo(f, ArgumentClass(param_decls, **attrs))
  File "/Users/*******/.local/pipx/venvs/cookie-composer/lib/python3.10/site-packages/click/core.py", line 2950, in __init__
    super().__init__(param_decls, required=required, **attrs)
TypeError: Parameter.__init__() got an unexpected keyword argument 'help'
```